### PR TITLE
OMNIKEY 3x21 and 6121 Smart Card Reader are not pinpad readers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: objective-c
-osx_image: xcode9.2
+osx_image: xcode9.4
 script: xcodebuild -project EstEIDTokenApp.xcodeproj -target package CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO DSTROOT=$PWD/tmp install

--- a/EstEIDToken/TokenSession.m
+++ b/EstEIDToken/TokenSession.m
@@ -96,6 +96,12 @@
     }
 
     TKTokenSmartCardPINAuthOperation *tokenAuth = [[EstEIDAuthOperation alloc] initWithSmartCard:self.smartCard];
+    if ([self.smartCard.slot.name containsString:@"HID Global OMNIKEY 3x21 Smart Card Reader"] ||
+        [self.smartCard.slot.name containsString:@"HID Global OMNIKEY 6121 Smart Card Reader"])
+    {
+        NSLog(@"EstEIDTokenSession beginAuthForOperation '%@' is not PinPad reader", self.smartCard.slot.name);
+        return tokenAuth;
+    }
 
     // workaround: macOS does not support PINPad templates
     TKSmartCardUserInteractionForSecurePINVerification *pinpad = [self.smartCard userInteractionForSecurePINVerificationWithPINFormat:tokenAuth.PINFormat APDU:tokenAuth.APDUTemplate PINByteOffset:tokenAuth.PINByteOffset];


### PR DESCRIPTION
macOS 10.13 ships with ccid driver 1.4.27 (fixed in 1.4.29) and this version identifies these readers wrongly as pinpad readers.

IB-5365

Signed-off-by: Raul Metsma <raul@metsma.ee>